### PR TITLE
#9 modify global description and twitter card

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -1,6 +1,7 @@
 module.exports = {
   title: '✈︎ dlopp.',
   domain: 'https://dlopp-docs.netlify.app',
+  description: 'web開発プロジェクトdloppの資料置き場兼ブログです。',
   themeConfig: {
     nav: [
       { text: 'Home', link: '/' },

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -25,6 +25,7 @@ module.exports = {
       description: ($page, $site) => $page.frontmatter.description || ($page.excerpt && $page.excerpt.replace(/<("[^"]*"|'[^']*'|[^'">])*>/g, "")) || $site.description || "",
       title: ($page, $site) => $page.title || $site.title,
       image: ($page, $site) => $page.frontmatter.image && (($site.themeConfig.domain || '') + $page.frontmatter.image) || 'https://i.gyazo.com/96879cdaad2e8524dce6252ec6270162.jpg',
+      twitterCard: _ => 'summary',
     }
   },
 }

--- a/src/about/index.md
+++ b/src/about/index.md
@@ -2,9 +2,6 @@
 title: dloppについて
 description: 'dloppとは、和歌山大学協働教育センター(クリエ)で立ち上げられたweb開発プロジェクトです'
 sidebar: false
-meta:
-  - name: twitter:card
-    content: summary
 ---
 # dloppについて
 

--- a/src/index.md
+++ b/src/index.md
@@ -1,6 +1,6 @@
 ---
 home: true
-description: '資料置き場的な'
+description: 'dloppの資料置き場兼ブログ'
 footer: © 2020 dlopp
 ---
 ## 🛠-鋭意作成中....


### PR DESCRIPTION
## 概要
1.　frontmatterに何も書いてなかったら表示する用のdescriptionを追加しました。
2.　twitterカードのデフォルトを小さいほうに修正しました。

## 関連
#9 

## 備考
- descriptionは毎度書いた方が良さそうなので一応って感じです
- meta系の設定はseoプラグインの[公式README](https://github.com/lorisleiva/vuepress-plugin-seo#vuepress-plugin-seo)にいろいろオプションが書かれてるので、それを参考にしてください。
- meta-dataをそのページだけいじりたいときはfrontmatterに書いてください。下の書き方で適切なnameとcontentを書くとそっちが優先されます。

```
meta:	
  - name: 	
    content: 
```
