### PR TITLE
最終更新日時の表示

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -2,6 +2,7 @@ module.exports = {
   title: '✈︎ dlopp.',
   domain: 'https://dlopp-docs.netlify.app',
   themeConfig: {
+    sidebar: 'auto',
     lastUpdated: '最終更新日時',
     nav: [
       { text: 'Home', link: '/' },
@@ -17,7 +18,11 @@ module.exports = {
         ]
       }
     ],
-    sidebar: 'auto',
+  },
+  locales: {
+    '/': {
+      lang: 'ja',
+    },
   },
   plugins: {
     '@vuepress/blog': {},

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -2,6 +2,7 @@ module.exports = {
   title: '✈︎ dlopp.',
   domain: 'https://dlopp-docs.netlify.app',
   themeConfig: {
+    lastUpdated: '最終更新日時',
     nav: [
       { text: 'Home', link: '/' },
       { text: 'About', link: '/about/' },


### PR DESCRIPTION
## 概要
![2020-11-28 (2)](https://user-images.githubusercontent.com/67625825/100494865-5ae26880-3189-11eb-97c1-4316bf608681.png)

## 備考
もともとある機能を有効化しただけです。記事ページだけに表示してくれるようです。