### PR TITLE
dayjs使って、更新日時のフォーマット変えてみた

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@vuepress/plugin-blog": "^1.9.3",
     "@vuepress/plugin-medium-zoom": "^1.7.1",
+    "dayjs": "^1.9.6",
     "vuepress": "^1.7.1",
     "vuepress-plugin-seo": "^0.1.4"
   },

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -33,6 +33,13 @@ module.exports = {
       title: ($page, $site) => $page.title || $site.title,
       image: ($page, $site) => $page.frontmatter.image && (($site.themeConfig.domain || '') + $page.frontmatter.image) || 'https://i.gyazo.com/96879cdaad2e8524dce6252ec6270162.jpg',
       twitterCard: _ => 'summary',
-    }
+    },
+    '@vuepress/last-updated': {
+      transformer: (timestamp, lang) => {
+        const dayjs = require('dayjs')
+        dayjs.locale(lang)
+        return dayjs(timestamp).format('YYYY/MM/DD H時m分');
+      },
+    },
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2751,7 +2751,7 @@ date-fns@^1.29.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-dayjs@^1.8.19:
+dayjs@^1.8.19, dayjs@^1.9.6:
   version "1.9.6"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.6.tgz#6f0c77d76ac1ff63720dd1197e5cb87b67943d70"
   integrity sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw==


### PR DESCRIPTION
## 概要
記事ページの最下部に表示されてる、updateの日付フォーマットがきもかったので、dayjs使ってなおしてみました。

もともと
![スクリーンショット 2020-12-02 224739](https://user-images.githubusercontent.com/67625825/100880722-6f5b9380-34f0-11eb-99b9-b4e6bb432ce7.png)

変更後
![2020-12-02 (2)](https://user-images.githubusercontent.com/67625825/100880617-463b0300-34f0-11eb-89bb-f612836db908.png)


## 備考
- last-updatedプラグインの[公式ドキュメント](https://vuepress.vuejs.org/plugin/official/plugin-last-updated.html#transformer)と、dayjsの[ドキュメント](https://day.js.org/docs/en/display/format)見ながらやりました。
